### PR TITLE
Keep some things when model changes, not all

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     NMdata,
     nonmem2R,
     withr,
-    nlme
+    nlme,
+    dplyr
 Config/testthat/edition: 3
 RoxygenNote: 7.2.3

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -1,6 +1,12 @@
-.nonmem2rxExtraSave <- c("nonmemData", "etaData", "ipredAtol", "ipredRtol",
-                         "ipredCompare", "predAtol", "predRtol", "predCompare",
-                         "sigma", "thetaMat", "dfSub", "dfObs")
+.nonmem2rxExtraSaveFull <- c("nonmemData", "etaData", "ipredAtol", "ipredRtol",
+                             "ipredCompare", "predAtol", "predRtol", "predCompare",
+                             "sigma", "thetaMat", "dfSub", "dfObs", "atol", "rtol",
+                             "ssRtol", "ssAtol")
+
+.nonmem2rxExtraSaveMin <- c("nonmemData", "sigma","atol", "rtol", "ssRtol", "ssAtol")
+
+.nonmem2rxExtraFullOnly <-  setdiff(.nonmem2rxExtraSaveFull, .nonmem2rxExtraSaveMin)
+
 
 .stripAndSaveObj <- function(x) {
   .env <- new.env(parent=emptyenv())
@@ -9,19 +15,34 @@
   .clsX <- .clsX[-which(.clsX == "nonmem2rx")]
   class(.x) <- .clsX
   .x <- rxode2::rxUiDecompress(.x)
-  for (.v in .nonmem2rxExtraSave) {
+  for (.v in .nonmem2rxExtraSaveFull) {
     if (exists(.v, envir=.x)) {
       assign(.v, get(.v, envir=.x), envir=.env)
     }
   }
-  list(.env, .x)
+  list(.env, .x, length(intersect(ls(.env), .nonmem2rxExtraFullOnly)) > 0L)
 }
 
-.dressAndSaveObj <- function(x, env, compress=TRUE) {
+.dressAndSaveObj <- function(x, env, compress=TRUE, full=TRUE) {
   .new <- rxode2::rxUiDecompress(x)
+  if (full) {
+    .nonmem2rxExtraSave <- .nonmem2rxExtraSaveFull
+  } else {
+    .nonmem2rxExtraSave <- .nonmem2rxExtraSaveMin
+  }
   for (.v in .nonmem2rxExtraSave) {
     if (exists(.v, envir=env)) {
       assign(.v, get(.v, envir=env), envir=.new)
+    }
+  }
+  if (!full) {
+    for (.v in .nonmem2rxExtraFullOnly) {
+      if (exists(.v, envir=env)) {
+        .minfo(sprintf("dropping '$%s' from nonmem2rx ui since model changed", .v))
+        if (exists(.v, envir=.new)) {
+          rm(list=.v, envir=.new)
+        }
+      }
     }
   }
   if (compress) .new <- rxode2::rxUiCompress(.new)
@@ -36,13 +57,26 @@ ini.nonmem2rx <- function(x, ..., envir = parent.frame(), append = NULL) {
   .tmp <- .stripAndSaveObj(x)
   .ret <- .tmp[[2]]
   .iniDf <- .ret$iniDf
+  .hasFull <- .tmp[[3]]
+  if (.hasFull) {
+    .pre <- .iniDf[,c("name", "est")]
+    names(.pre)[2] <- "estPre"
+  }
   .iniLines <- rxode2::.quoteCallInfoLines(match.call(expand.dots = TRUE)[-(1:2)], 
                                            envir = envir, iniDf = .iniDf)
   lapply(.iniLines, function(line) {
     rxode2::.iniHandleLine(expr = line, rxui = .ret, envir = envir, 
                            append = append)
   })
-  .dressAndSaveObj(.ret, .tmp[[1]])
+  if (.hasFull) {
+    # if none of the estimates have changed, don't change nonmem info
+    .post <- .ret$iniDf[,c("name", "est")]
+    .both <- merge(.pre, .post, all.x=TRUE, all.y=TRUE, by="name")
+    .fullSave <- all(.both$est==.both$estPre)
+  } else {
+    .fullSave <- FALSE
+  }
+  .dressAndSaveObj(.ret, .tmp[[1]], full=.fullSave)
 }
 
 
@@ -57,7 +91,8 @@ model.nonmem2rx <- function(x, ..., append = FALSE,
                                              envir = envir)
   rxode2::.modelHandleModelLines(.modelLines, .ret, modifyIni = FALSE, 
                                  append = append, auto = auto, envir = envir)
-  .dressAndSaveObj(.ret, .tmp[[1]])
+  # always drop extra model information
+  .dressAndSaveObj(.ret, .tmp[[1]], full=FALSE)
 }
 
 
@@ -89,8 +124,9 @@ rxRename.nonmem2rx <- function(.data, ...) {
   .lst$.data <- .tmp[[2]]
   .rxui <- .tmp[[2]]
   .vars <- unique(c(.rxui$mv0$state, .rxui$mv0$params, .rxui$mv0$lhs, .rxui$predDf$var, .rxui$predDf$cond, .rxui$iniDf$name))
+  # keep extra model information if it is already there
   .rxui <- .dressAndSaveObj(do.call(rxode2::.rxRename, c(.lst, list(envir = parent.frame(2)))),
-                            .tmp[[1]], compress=FALSE)
+                            .tmp[[1]], compress=FALSE, full=TRUE)
   .lst <- lapply(seq_along(.modelLines), function(i) {
     rxode2::.assertRenameErrorModelLine(.modelLines[[i]], .vars)
   })
@@ -101,3 +137,4 @@ rxRename.nonmem2rx <- function(.data, ...) {
   rxode2::rxUiCompress(.rxui)
 }
 
+rename.nonmem2rx <- rxRename.nonmem2rx

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,6 +3,10 @@
   if (requireNamespace("nlme", quietly=TRUE)) {
     rxode2::.s3register("nlme::getData", "nonmem2rx")
   }
+  if (requireNamespace("dplyr", quietly=TRUE)) {
+    rxode2::.s3register("dplyr::rename", "nonmem2rx")
+  }
+
 }
 .onAttach <- function(libname,pkgname){
   .Call(`_nonmem2rx_r_parseIni`)

--- a/tests/testthat/test-piping.R
+++ b/tests/testthat/test-piping.R
@@ -4,15 +4,35 @@
 
 test_that("piping works", {
   skip_on_cran()
+
   f <- .nonmem2rx(system.file("mods/cpt/runODE032.ctl", package="nonmem2rx"), lst=".res")
+
   expect_true(inherits(f, "nonmem2rx"))
   expect_false(is.null(f$nonmemData))
+  expect_true(!is.null(f$dfSub))
+
   f2 <- f %>% ini(eta1 ~ 0.1)
   expect_true(inherits(f2, "nonmem2rx"))
   expect_false(is.null(f2$nonmemData))
+  expect_true(is.null(f2$dfSub))
 
   f2 <- f %>% model(cl <- exp(theta1))
   expect_true(inherits(f2, "nonmem2rx"))
   expect_false(is.null(f2$nonmemData))
-  
+  expect_true(is.null(f2$dfSub))
+
+  f2 <- f %>% ini(eta1=fixed)
+  expect_false(is.null(f2$nonmemData))
+  expect_true(!is.null(f2$dfSub))
+
+  f2 <- f %>% rxRename(eta.v=eta2)
+  expect_false(is.null(f2$nonmemData))
+  expect_true(!is.null(f2$dfSub))
+
+  f2 <- f %>% dplyr::rename(eta.v=eta2)
+  expect_false(is.null(f2$nonmemData))
+  expect_true(!is.null(f2$dfSub))
+
+
+
 })


### PR DESCRIPTION
In most circumstances the following are kept:

- imported NONMEM data
- class (so that we know to use different solving options)
- Specified `atol`/`rtol` and steady state values from `$sub`
- `sigma` from NONMEM, which doesn't have a place in the current ui.

The other items (`thetaMat`, `etaData`, `ipredAtol`,  `ipredRtol`,  `ipredCompare`, `predAtol`,
 `predRtol`     `predCompare`  `thetaMat`     `dfSub`        `dfObs`) are kept only when the model itself does not change in a significant way (ie no changes in initial estimates and no changes in model structure).

I think this is the right solution.  