### PR TITLE
Always rename `ytype`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nonmem2rx
 Type: Package
 Title: Converts 'NONMEM' Models to 'rxode2'
-Version: 0.1.7
+Version: 0.1.7.9000
 Maintainer: Matthew Fidler <matthew.fidler@gmail.com>
 Authors@R: c(person("Matthew","Fidler", role = c("aut", "cre"), email = "matthew.fidler@gmail.com", comment=c(ORCID="0000-0001-8538-6691")),
     person("Philip", "Delff", email = "philip@delff.dk",role = c("ctb")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# nonmem2rx (development version)
+
 # nonmem2rx 0.1.7
 
 * Added `$ERROR (ONLY OBS)` support

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # nonmem2rx (development version)
 
+* Better handling of `ytype`
+
 # nonmem2rx 0.1.7
 
 * Added `$ERROR (ONLY OBS)` support

--- a/R/readInNonmemInput.R
+++ b/R/readInNonmemInput.R
@@ -96,6 +96,10 @@
       .minfo("renaming 'ytype' to 'nmytype'")
       .wyt <- which(tolower(names(.data)) == "ytype")
       names(.data)[.wyt] <- "nmytype"
+    } else {
+      .minfo("renaming 'ytype' to 'nmytype'")
+      .wyt <- which(tolower(names(.data)) == "ytype")
+      names(.data)[.wyt] <- "nmytype"
     }
     if (.nonmem2rx$needDvid) {
       .minfo("renaming 'dvid' to 'nmdvid'")

--- a/src/abbrev.c
+++ b/src/abbrev.c
@@ -103,6 +103,7 @@ int extendedCtrlInt = 0;
 SEXP nonmem2rxGetScale(int scale);
 
 int evidWarning = 0;
+int ytypeWarning = 0;
 int idWarning = 0;
 int icallWarning = 0;
 int irepWarning = 0;
@@ -277,6 +278,15 @@ int abbrev_identifier_or_constant(char *name, int i, D_ParseNode *pn) {
       }
       sAppendN(&curLine, "nmevid", 6);
       return 1;
+    } else if (!nmrxstrcmpi("ytype", v)) {
+      if (evidWarning == 0) {
+        Rf_warning("'ytype' variable has a special meaning in rxode2, renamed to 'nmytype', rename/copy in your data too");
+        ytypeWarning = 1;
+        nonmem2rxNeedYtype();
+      }
+      sAppendN(&curLine, "nmytype", 7);
+      return 1;
+
     } else if (!nmrxstrcmpi("amt", v)) {
       // make sure amt is lower case; works around a parser bug in rxode2parse
       sAppendN(&curLine, "amt", 3);
@@ -1323,6 +1333,7 @@ SEXP _nonmem2rx_trans_abbrev(SEXP in, SEXP prefix, SEXP abbrevLinSEXP, SEXP exte
   includeWarning = 0;
   maxA = 0;
   evidWarning=0;
+  ytypeWarning = 0;
   idWarning=0;
   simWarning=0;
   ipredSimWarning=0;


### PR DESCRIPTION
If ytype is in the data and not the model, rename