### PR TITLE
Range-check rc_dup_str length to prevent silent int truncation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# nonmem2rx 0.1.11
+
+* Fix implicit `ptrdiff_t` to `int` truncation in `rc_dup_str`
+  (`src/records.c`).  When the parser passes a string segment longer
+  than `INT_MAX` bytes (or a NUL-terminated string of that length),
+  the pointer difference / `strlen` result was silently cast to `int`,
+  truncating the length to a wrong (often negative) value.  The new
+  guard rejects such inputs with an informative R error.
+
 # nonmem2rx 0.1.10
 
 * Bug fix for covariance matrices that span multiple FORTRAN output pages

--- a/src/records.c
+++ b/src/records.c
@@ -24,7 +24,20 @@ int lastStrLoc=0;
 vLines _dupStrs;
 char * rc_dup_str(const char *s, const char *e) {
   lastStr=s;
-  int l = e ? e-s : (int)strlen(s);
+  int l;
+  if (e) {
+    ptrdiff_t diff = e - s;
+    if (diff < 0 || diff > (ptrdiff_t)INT_MAX) {
+      Rf_error(_("string segment too long in rc_dup_str"));
+    }
+    l = (int)diff;
+  } else {
+    size_t sLen = strlen(s);
+    if (sLen > (size_t)INT_MAX) {
+      Rf_error(_("string too long in rc_dup_str"));
+    }
+    l = (int)sLen;
+  }
   //syntaxErrorExtra=min(l-1, 40);
   addLine(&_dupStrs, "%.*s", l, s);
   return _dupStrs.line[_dupStrs.n-1];

--- a/tests/testthat/test-mem-rc-dup-str.R
+++ b/tests/testthat/test-mem-rc-dup-str.R
@@ -1,0 +1,33 @@
+test_that("rc_dup_str handles normal-sized inputs without error", {
+  # Sanity check: regular NONMEM control fragments must continue to parse
+  # cleanly after the INT_MAX guards added to rc_dup_str.
+  expect_no_error(
+    tryCatch(
+      .Call(`_nonmem2rx_trans_theta`, "(1, 2, 3)\n", 1L),
+      error = function(e) {
+        if (grepl("rc_dup_str", conditionMessage(e))) stop(e)
+        # Other parse errors are acceptable.
+        NULL
+      }
+    )
+  )
+})
+
+test_that("rc_dup_str int truncation guard triggers on huge inputs (skipped: requires ~2GB RAM)", {
+  skip("Requires ~2GB free RAM to construct a >INT_MAX-byte input string")
+  # --- What this test checks ---
+  # `rc_dup_str` (src/records.c) computes the length as
+  #   int l = e ? e-s : (int)strlen(s);
+  # When the source string segment is larger than INT_MAX bytes, the
+  # `(int)` cast silently truncates to a wrong value, which propagates
+  # into `addLine(&_dupStrs, "%.*s", l, s)`.
+  #
+  # The guard added by this fix range-checks the ptrdiff_t / size_t
+  # length and raises an R error before the truncation can happen.
+
+  big <- strrep("a", 2147483647L)
+  expect_error(
+    .Call(`_nonmem2rx_trans_abbrev`, big, "nlmixr2", 0L, 0L),
+    "rc_dup_str|too long"
+  )
+})


### PR DESCRIPTION
`rc_dup_str` (src/records.c) computed the segment length as
    int l = e ? e-s : (int)strlen(s);
where the source pointers come from the dparser parse tree.  When the source span exceeds INT_MAX bytes the implicit ptrdiff_t-to-int (or size_t-to-int) cast silently truncates to a wrong (often negative) value.  The downstream `addLine(&_dupStrs, "%.*s", l, s)` then either reads past the buffer or copies the wrong number of bytes.

Replace the silent cast with explicit range checks on both branches (`ptrdiff_t > INT_MAX` and `size_t > INT_MAX`) and raise a clean R error when out of range.

Adds tests/testthat/test-mem-rc-dup-str.R as a regression test.  The boundary test is `skip()`ed because it requires ~2 GB of free RAM.