### PR TITLE
rxSolve.nonmem2rx: use first ODE method as default (length-1)

### DIFF
--- a/R/buildParser.R
+++ b/R/buildParser.R
@@ -96,6 +96,12 @@
 .nonmem2rxBuildRxSolve <- function() {
   message("build options for rxSolve to match NONMEM")
   .args <- deparse1(eval(str2lang(paste0("args(rxode2::rxSolve)"))))
+  # Keep only the first (preferred) ODE method as the default. rxode2's full
+  # multi-element `method` default is frozen here at build time and goes stale;
+  # a stale multi-element default that no longer matches rxode2's own default
+  # trips odeMethodToInt()'s match.arg() ("'arg' must be of length 1") when the
+  # solve is dispatched. The first element is the default rxode2 would pick.
+  .args <- sub('method = c\\(("[^"]*")[^)]*\\)', "method = \\1", .args)
   .first <- c(strsplit(.args, "[.][.][.]"))[[1]][1]
   .first <- paste(.first,
                   "..., ",

--- a/R/rxSolve.R
+++ b/R/rxSolve.R
@@ -1,8 +1,7 @@
 # This is built from buildParser.R, edit there
 #'@export
 rxSolve.nonmem2rx <- function(object, params = NULL, events = NULL, 
-    inits = NULL, scale = NULL, method = c("liblsoda", "lsoda", 
-        "dop853", "indLin"), sigdig = NULL, atol = 1e-08, rtol = 1e-06, 
+    inits = NULL, scale = NULL, method = "liblsoda", sigdig = NULL, atol = 1e-08, rtol = 1e-06,
     maxsteps = 70000L, hmin = 0, hmax = NA_real_, hmaxSd = 0, 
     hini = 0, maxordn = 12L, maxords = 5L, ..., cores, covsInterpolation = c("locf", 
         "linear", "nocb", "midpoint"), naInterpolation = c("locf", 


### PR DESCRIPTION
## Problem
Same as monolix2rx: `rxSolve.nonmem2rx` is generated by `buildParser.R` from a
build-time snapshot of `args(rxode2::rxSolve)`, freezing rxode2's old multi-element
`method` default `c("liblsoda","lsoda","dop853","indLin")`. That stale default trips
rxode2's `odeMethodToInt()` `match.arg()` ("'arg' must be of length 1") when a
nonmem2rx object is solved.

## Fix
Capture only the first (preferred) method in `buildParser.R` (length-1 default
`"liblsoda"`); regenerated `R/rxSolve.R` updated to match. Verified `test-rxsolve`
passes (0 failures), including against an unmodified rxode2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)