### PR TITLE
Translate NONMEM mixture models to native rxode2/nlmixr2 mix()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,19 @@
 # nonmem2rx 0.1.11
 
 
+* NONMEM mixture models (`$MIX`) now translate to the native rxode2/nlmixr2
+  mixture support (`mix()`), replacing the previous `rxord()` simulation of
+  the sub-population.  When the mixture probabilities are simple parameters
+  (e.g. `P(1)=THETA(5)`), the imperative `MIXNUM`/`MIXEST` branching in
+  `$PK`/`$PRED` is collapsed into readable `mix()` calls (e.g.
+  `V <- mix(VCM, p1, VCF)`), the probabilities are registered on the model
+  (`ui$mixProbs`) so the model estimates natively under `focei` and `saem`,
+  and `MIXEST`/`MIXNUM` map to the reserved `mixest` component.  Models whose
+  probabilities are not simple parameters fall back to the previous `rxord()`
+  translation.  Simulation-based validation remains gated for mixtures because
+  NONMEM's per-subject sub-population assignment is not recoverable for a
+  faithful prediction comparison.
+
 * Support the NONMEM `$DATA` numeric-comparison operators `.EQN.` and
   `.NEN.` in `IGNORE=`/`ACCEPT=` filters (#195).  These request that the
   data item be converted to numeric before being compared, so they now

--- a/R/abbrev.R
+++ b/R/abbrev.R
@@ -57,16 +57,64 @@ nonmem2rxRec.mix <- function(x) {
     stop("probabilities in mixture models must specify all sequential values, ie, P(1), P(2)",
          call.=FALSE)
   }
-  # define the simulated mixnum
-  .addModel(paste0("NMMIXNUM <- rxord(",
-                   paste(paste0("rxp.", .nonmem2rx$mixp[-length(.nonmem2rx$mixp)],"."),
-                         collapse=", "),
-                   ")"))
+  # Prefer a native rxode2/nlmixr2 mixture translation using mix(): the
+  # nlmixr2est mixture machinery is driven by `ui$mixProbs`, which is populated
+  # when a mix() call appears in the model.  For NONMEM's imperative MIXNUM/MIXEST
+  # code we register the probabilities with a dummy mix() and alias NMMIXNUM to the
+  # reserved `mixest` variable so estimation loops over the sub-populations (see
+  # `.mixProbNames`).  When the probabilities are not simple ini() parameters we
+  # fall back to the legacy rxord() simulation.
+  .probNames <- .mixProbNames(.nonmem2rx$nspop)
+  if (!is.null(.probNames)) {
+    .nonmem2rx$mixNative <- TRUE
+    .nonmem2rx$mixProbNames <- .probNames
+    # NMMIXNUM (from MIXNUM/MIXEST in the grammar) aliases the estimated component
+    .addModel("NMMIXNUM <- mixest")
+    # dummy mix() registers the probabilities (components are constant, the real
+    # sub-population values come from the imperative code that references NMMIXNUM)
+    .addModel(paste0("rxMixDummy <- mix(",
+                     paste(c(rbind(rep("1", length(.probNames)), .probNames), "1"),
+                           collapse=", "),
+                     ")"))
+  } else {
+    .minfo("mixture probabilities are not simple parameters; using legacy rxord() simulation")
+    .addModel(paste0("NMMIXNUM <- rxord(",
+                     paste(paste0("rxp.", .nonmem2rx$mixp[-length(.nonmem2rx$mixp)],"."),
+                           collapse=", "),
+                     ")"))
+  }
   .addModel("cur.mixp <- -1")
   # define cur.mixp which nonmem translates from MIXP and MIXP(MIXNUM)
   .addModel(paste(paste0("if (NMMIXNUM == ", .nonmem2rx$mixp, ") cur.mixp <- rxp.", .nonmem2rx$mixp, "."),
                   collapse="\n"))
   # MIXP(#) is translated in the grammar
+}
+#' Determine the mixture probability parameter names for a native mix() translation
+#'
+#' The `prob` grammar rule emits `rxp.<k>. <- <expr>` lines for each `P(k)=`.  A
+#' native mix() translation needs the first `nMix - 1` probabilities to each be a
+#' bare population parameter already defined in the ini() block (the last
+#' probability is implicit, `1 - sum(others)`).
+#'
+#' @param nMix Number of mixture sub-populations (NSPOP)
+#' @return Character vector of length `nMix - 1` with the probability parameter
+#'   names, or `NULL` when the probabilities cannot be expressed as ini parameters
+#'   (signalling the legacy rxord() fallback)
+#' @noRd
+#' @author Matthew L. Fidler
+.mixProbNames <- function(nMix) {
+  if (nMix < 2L) return(NULL)
+  .iniNames <- sub("^\\s*([A-Za-z0-9._]+)\\s*(<-|=).*$", "\\1",
+                   grep("(<-|=)", .nonmem2rx$ini, value=TRUE))
+  .names <- character(nMix - 1L)
+  for (.k in seq_len(nMix - 1L)) {
+    .line <- grep(paste0("^rxp\\.", .k, "\\. <- "), .nonmem2rx$model, value=TRUE)
+    if (length(.line) != 1L) return(NULL)
+    .rhs <- trimws(sub(paste0("^rxp\\.", .k, "\\. <- "), "", .line))
+    if (!(.rhs %in% .iniNames)) return(NULL)
+    .names[.k] <- .rhs
+  }
+  .names
 }
 
 #' @export

--- a/R/mix.R
+++ b/R/mix.R
@@ -1,0 +1,117 @@
+#' Interleave mixture component expressions with the probability names
+#'
+#' Builds the argument list for a `mix()` call from a vector of component
+#' expressions and the probability parameter names, i.e. `E1, p1, E2, p2, ..., En`.
+#'
+#' @param components Character vector of length `nMix` with the component expressions
+#' @param probNames Character vector of length `nMix - 1` with the probability names
+#' @return Single string: the `mix(...)` call
+#' @noRd
+#' @author Matthew L. Fidler
+.nonmemMixCall <- function(components, probNames) {
+  .n <- length(components)
+  .args <- character(0)
+  for (.i in seq_len(.n - 1L)) {
+    .args <- c(.args, components[.i], probNames[.i])
+  }
+  .args <- c(.args, components[.n])
+  paste0("mix(", paste(.args, collapse = ", "), ")")
+}
+
+#' Collapse imperative MIXNUM/MIXEST branching into native mix() calls
+#'
+#' Rewrites the canonical NONMEM mixture idiom that assigns a single variable per
+#' sub-population into a readable `mix()` call.  A "mixture group" for a variable
+#' `V` is an optional leading default assignment `V <- E` (which pre-fills every
+#' sub-population) followed by one or more consecutive `if (NMMIXNUM == k) V <- Ek`
+#' overrides for the same `V`.  This covers both:
+#'
+#' * per-component `if`s: `if (NMMIXNUM == 1) V <- E1` ... `if (NMMIXNUM == n) V <- En`
+#' * default + overrides: `V <- E1` then `if (NMMIXNUM == k) V <- Ek`
+#'
+#' Both collapse to `V <- mix(E1, p1, E2, ..., En)` once every sub-population has
+#' an expression.  Lines that cannot be collapsed are returned unchanged (the
+#' caller aliases the remaining `NMMIXNUM` references to the reserved `mixest`).
+#'
+#' @param lines Character vector of model lines (the mixture variable referenced
+#'   as `NMMIXNUM`)
+#' @param nMix Number of mixture sub-populations
+#' @param probNames Character vector of length `nMix - 1` with the probability names
+#' @return `list(lines=, emittedMix=)` where `emittedMix` is `TRUE` when at least
+#'   one native `mix()` call was produced
+#' @noRd
+#' @author Matthew L. Fidler
+.nonmemMixCollapse <- function(lines, nMix, probNames) {
+  # some model elements bundle several statements joined by newlines (e.g. the
+  # per-component cur.mixp `if`s); operate one statement per line
+  lines <- unlist(strsplit(lines, "\n", fixed = TRUE))
+  .ifRe <- "^if \\(NMMIXNUM == ([0-9]+)\\) ([A-Za-z0-9._]+) <- (.*)$"
+  .asgnRe <- "^([A-Za-z0-9._]+) <- (.*)$"
+  .out <- character(0)
+  .emitted <- FALSE
+  .i <- 1L
+  .n <- length(lines)
+  while (.i <= .n) {
+    .line <- lines[.i]
+    .collapsed <- FALSE
+    # identify the variable and optional leading default for a mixture group
+    .var <- NULL
+    .comp <- rep(NA_character_, nMix)
+    .j <- .i
+    if (grepl(.asgnRe, .line) && !grepl("^if ", .line) && !grepl("<- mix\\(", .line)) {
+      .var <- sub(.asgnRe, "\\1", .line)
+      .comp[] <- sub(.asgnRe, "\\2", .line)  # default fills every sub-population
+      .j <- .i + 1L
+    } else if (grepl(.ifRe, .line)) {
+      .var <- sub(.ifRe, "\\2", .line)
+    }
+    if (!is.null(.var)) {
+      # consume consecutive per-component overrides for the same variable
+      .nIf <- 0L
+      while (.j <= .n && grepl(.ifRe, lines[.j]) && sub(.ifRe, "\\2", lines[.j]) == .var) {
+        .num <- as.integer(sub(.ifRe, "\\1", lines[.j]))
+        if (.num >= 1L && .num <= nMix) .comp[.num] <- sub(.ifRe, "\\3", lines[.j])
+        .nIf <- .nIf + 1L
+        .j <- .j + 1L
+      }
+      if (.nIf > 0L && !anyNA(.comp)) {
+        .out <- c(.out, paste0(.var, " <- ", .nonmemMixCall(.comp, probNames)))
+        .emitted <- TRUE
+        .i <- .j
+        .collapsed <- TRUE
+      }
+    }
+    if (!.collapsed) {
+      .out <- c(.out, .line)
+      .i <- .i + 1L
+    }
+  }
+  list(lines = .out, emittedMix = .emitted)
+}
+
+#' Finalize the mixture translation into native mix() model code
+#'
+#' Post-parse pass (run after all records, so `$PK`/`$PRED` code is available):
+#' collapses collapsible MIXNUM/MIXEST branching into `mix()` calls, aliases any
+#' remaining `NMMIXNUM` references to the reserved `mixest`, and drops the dummy
+#' `mix()` / alias scaffolding once a real `mix()` call carries the probabilities.
+#'
+#' @return Nothing, mutates `.nonmem2rx$model`
+#' @noRd
+#' @author Matthew L. Fidler
+.nonmem2rxMix <- function() {
+  if (!isTRUE(.nonmem2rx$mixNative)) return(invisible(NULL))
+  .probNames <- .nonmem2rx$mixProbNames
+  .nMix <- .nonmem2rx$nspop
+  .res <- .nonmemMixCollapse(.nonmem2rx$model, .nMix, .probNames)
+  .lines <- .res$lines
+  if (.res$emittedMix) {
+    # a real mix() now registers the probabilities: the dummy call is redundant
+    .lines <- .lines[!grepl("^rxMixDummy <- mix\\(", .lines)]
+    # any leftover imperative branching keys off the reserved `mixest`
+    .lines <- gsub("\\bNMMIXNUM\\b", "mixest", .lines)
+    .lines <- .lines[!grepl("^mixest <- mixest$", .lines)]
+  }
+  assign("model", .lines, envir = .nonmem2rx)
+  invisible(NULL)
+}

--- a/R/nonmem2rx.R
+++ b/R/nonmem2rx.R
@@ -744,6 +744,9 @@ nonmem2rx <- function(file, inputData=NULL, nonmemOutputDir=NULL,
                })
       }
     }
+    # collapse imperative MIXNUM/MIXEST branching into native mix() calls now that
+    # the full $PK/$PRED code has been parsed
+    .nonmem2rxMix()
     .txt <- paste0("function() {\n",
                    "rxode2::ini({\n",
                    paste(.nonmem2rx$ini, collapse="\n"),

--- a/R/nonmem2rx.R
+++ b/R/nonmem2rx.R
@@ -782,7 +782,13 @@ nonmem2rx <- function(file, inputData=NULL, nonmemOutputDir=NULL,
     .msg <- NULL
     if (validate) {
       if (length(.nonmem2rx$mixp) > 0) {
-        .minfo("mixture model, not currently validated")
+        # The model is now a native mixture (mix()/mixest) that simulates and
+        # estimates, but simulation draws the sub-population randomly (mixunif)
+        # whereas NONMEM assigns each subject its estimated component (MIXEST),
+        # which NONMEM does not expose as a recoverable per-subject column here.
+        # Without that assignment a faithful prediction comparison is not
+        # possible, so validation stays gated (see NEWS / plan for enabling it).
+        .minfo("native mixture model; simulation-based validation skipped (per-subject sub-population not recoverable)")
         .msg <- "mixture model; not validated"
         validate <- FALSE
       }

--- a/R/nonmem2rx.R
+++ b/R/nonmem2rx.R
@@ -70,6 +70,8 @@
   .nonmem2rx$needExtCalc <- TRUE
   .nonmem2rx$mixp <- integer(0)
   .nonmem2rx$nspop <- 0L
+  .nonmem2rx$mixProbNames <- character(0)
+  .nonmem2rx$mixNative <- FALSE
   .nonmem2rx$advan5 <- NULL
   .nonmem2rx$advan5max <- 0L
   .nonmem2rx$advan5k <- NULL

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -1,0 +1,44 @@
+test_that("NONMEM $MIX translates to a native rxode2/nlmixr2 mix() model", {
+  skip_on_cran()
+
+  .f <- system.file("mods/bauer_2019_cptpsp_tutorial_2/supp7/pmixture_foce.ctl",
+                    package = "nonmem2rx")
+  skip_if(.f == "", "bauer supp7 pmixture fixture not installed")
+
+  .m <- suppressWarnings(nonmem2rx(.f, validate = FALSE, save = FALSE))
+  .model <- paste(deparse(.m$modelFun), collapse = "\n")
+
+  # The mixture machinery in nlmixr2est is driven by ui$mixProbs; a native
+  # translation must register it (here from P(1)=THETA(5), named "Initial").
+  expect_true(length(.m$mixProbs) > 0)
+  expect_equal(.m$mixProbs, "Initial")
+
+  # A real mix() call is emitted so the UI populates mixProbs on parse.
+  expect_match(.model, "mix\\(", perl = TRUE)
+
+  # MIXNUM/MIXEST branching is driven by the reserved `mixest`, not the old
+  # rxord() simulation.
+  expect_match(.model, "mixest", perl = TRUE)
+  expect_no_match(.model, "rxord\\(", perl = TRUE)
+
+  # BESTSUB = MIXEST becomes the assigned component (mixest via the alias).
+  expect_match(.model, "rxm.bestsub", perl = TRUE)
+})
+
+test_that("native mixture emission generalizes across the bauer mixture fixtures", {
+  skip_on_cran()
+
+  .files <- c("mods/bauer_2019_cptpsp_tutorial_2/supp7/pmixture_foce.ctl",
+              "mods/bauer_2019_cptpsp_tutorial_2/supp7/pmixture_saem.ctl",
+              "mods/bauer_2019_cptpsp_tutorial_2/supp7/pmixture_bayes.ctl")
+
+  for (.rel in .files) {
+    .f <- system.file(.rel, package = "nonmem2rx")
+    if (.f == "") next
+    .m <- suppressWarnings(nonmem2rx(.f, validate = FALSE, save = FALSE))
+    .model <- paste(deparse(.m$modelFun), collapse = "\n")
+    expect_true(length(.m$mixProbs) > 0, info = .rel)
+    expect_match(.model, "mix\\(", perl = TRUE, info = .rel)
+    expect_no_match(.model, "rxord\\(", perl = TRUE, info = .rel)
+  }
+})

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -1,3 +1,64 @@
+test_that(".nonmemMixCall interleaves components and probabilities", {
+  expect_equal(nonmem2rx:::.nonmemMixCall(c("a", "b"), "p1"),
+               "mix(a, p1, b)")
+  expect_equal(nonmem2rx:::.nonmemMixCall(c("a", "b", "c"), c("p1", "p2")),
+               "mix(a, p1, b, p2, c)")
+})
+
+test_that(".nonmemMixCollapse rewrites per-component `if` groups into mix()", {
+  .collapse <- nonmem2rx:::.nonmemMixCollapse
+
+  # Pattern: default sentinel + one `if` per component (the cur.mixp idiom)
+  .lines <- c("cur.mixp <- -1",
+              "if (NMMIXNUM == 1) cur.mixp <- rxp.1.",
+              "if (NMMIXNUM == 2) cur.mixp <- rxp.2.")
+  .r <- .collapse(.lines, 2L, "p1")
+  expect_true(.r$emittedMix)
+  expect_equal(.r$lines, "cur.mixp <- mix(rxp.1., p1, rxp.2.)")
+
+  # Pattern: default value + single override (the Q idiom)
+  .r2 <- .collapse(c("Q <- 1", "if (NMMIXNUM == 2) Q <- 0"), 2L, "p1")
+  expect_true(.r2$emittedMix)
+  expect_equal(.r2$lines, "Q <- mix(1, p1, 0)")
+
+  # Pattern: only per-component `if`s, no default
+  .r3 <- .collapse(c("if (NMMIXNUM == 1) TVCL <- theta1",
+                     "if (NMMIXNUM == 2) TVCL <- theta2"), 2L, "p1")
+  expect_true(.r3$emittedMix)
+  expect_equal(.r3$lines, "TVCL <- mix(theta1, p1, theta2)")
+
+  # Three sub-populations
+  .r4 <- .collapse(c("if (NMMIXNUM == 1) V <- v1",
+                     "if (NMMIXNUM == 2) V <- v2",
+                     "if (NMMIXNUM == 3) V <- v3"), 3L, c("p1", "p2"))
+  expect_equal(.r4$lines, "V <- mix(v1, p1, v2, p2, v3)")
+
+  # newline-joined `if` block (as emitted by the mixture handler) is split first
+  .r5 <- .collapse(c("cur.mixp <- -1",
+                     "if (NMMIXNUM == 1) cur.mixp <- rxp.1.\nif (NMMIXNUM == 2) cur.mixp <- rxp.2."),
+                   2L, "p1")
+  expect_equal(.r5$lines, "cur.mixp <- mix(rxp.1., p1, rxp.2.)")
+})
+
+test_that(".nonmemMixCollapse leaves non-collapsible code untouched", {
+  .collapse <- nonmem2rx:::.nonmemMixCollapse
+
+  # a plain assignment with no following mixture `if` is not a mixture group
+  .r <- .collapse(c("Q <- 1", "V <- Q * VCM"), 2L, "p1")
+  expect_false(.r$emittedMix)
+  expect_equal(.r$lines, c("Q <- 1", "V <- Q * VCM"))
+
+  # incomplete coverage (missing a component) is not collapsed
+  .r2 <- .collapse(c("if (NMMIXNUM == 1) V <- v1"), 2L, "p1")
+  expect_false(.r2$emittedMix)
+  expect_equal(.r2$lines, "if (NMMIXNUM == 1) V <- v1")
+
+  # references to NMMIXNUM that are not a component assignment are preserved
+  .r3 <- .collapse(c("BESTSUB <- NMMIXNUM"), 2L, "p1")
+  expect_false(.r3$emittedMix)
+  expect_equal(.r3$lines, "BESTSUB <- NMMIXNUM")
+})
+
 test_that("NONMEM $MIX translates to a native rxode2/nlmixr2 mix() model", {
   skip_on_cran()
 
@@ -8,21 +69,19 @@ test_that("NONMEM $MIX translates to a native rxode2/nlmixr2 mix() model", {
   .m <- suppressWarnings(nonmem2rx(.f, validate = FALSE, save = FALSE))
   .model <- paste(deparse(.m$modelFun), collapse = "\n")
 
-  # The mixture machinery in nlmixr2est is driven by ui$mixProbs; a native
-  # translation must register it (here from P(1)=THETA(5), named "Initial").
+  # nlmixr2est mixtures are driven by ui$mixProbs; a native translation registers it
   expect_true(length(.m$mixProbs) > 0)
   expect_equal(.m$mixProbs, "Initial")
 
-  # A real mix() call is emitted so the UI populates mixProbs on parse.
+  # the imperative MIXNUM/MIXEST code collapses to readable mix() calls
   expect_match(.model, "mix\\(", perl = TRUE)
-
-  # MIXNUM/MIXEST branching is driven by the reserved `mixest`, not the old
-  # rxord() simulation.
-  expect_match(.model, "mixest", perl = TRUE)
+  # no leftover simulation scaffolding once real mix() calls carry the probabilities
   expect_no_match(.model, "rxord\\(", perl = TRUE)
+  expect_no_match(.model, "mixdummy", perl = TRUE, ignore.case = TRUE)
+  expect_no_match(.model, "nmmixnum", perl = TRUE, ignore.case = TRUE)
 
-  # BESTSUB = MIXEST becomes the assigned component (mixest via the alias).
-  expect_match(.model, "rxm.bestsub", perl = TRUE)
+  # BESTSUB = MIXEST becomes the assigned component (the reserved mixest)
+  expect_match(.model, "mixest", perl = TRUE)
 })
 
 test_that("native mixture emission generalizes across the bauer mixture fixtures", {


### PR DESCRIPTION
## Summary

NONMEM mixture models (`$MIX`) previously translated to an `rxord()` *simulation* of the sub-population plus imperative `if (NMMIXNUM == k) cur.mixp <- rxp.k.` code, and validation was force-disabled. That output never engaged nlmixr2est's native mixture estimation, which is driven entirely by `ui$mixProbs`.

This PR makes `$MIX` translate to the **native** rxode2/nlmixr2 `mix()` support so a translated mixture is a first-class nlmixr2 mixture.

## What changed

- **Native registration (`R/abbrev.R`).** When the mixture probabilities are simple ini parameters (the common case, e.g. `P(1)=THETA(5)`), the handler registers them via a `mix()` call and aliases `NMMIXNUM <- mixest` so the estimator loops over sub-populations. Non-simple probabilities fall back to the legacy `rxord()` translation. New helper `.mixProbNames`.
- **Readable collapse (`R/mix.R`, new).** A post-parse pass recognizes the canonical NONMEM idiom — an optional default assignment followed by per-sub-population `if (MIXNUM == k) V <- Ek` overrides — and rewrites it to `V <- mix(E1, p1, E2, ..., En)`. Once a real `mix()` call carries the probabilities, the dummy registration and `NMMIXNUM` alias are dropped. The bauer supp7 fixtures collapse fully (`cur.mixp`, `Q`, and `BESTSUB`) with no leftover scaffolding.
- **Validation message (`R/nonmem2rx.R`).** Kept gated for mixtures, with an honest reason (per-subject sub-population not recoverable for a faithful comparison).
- **Docs.** `NEWS.md` entry.

## Correctness

The `mixest` mapping is verified empirically: an imperative `if (mixest==k)` fit matches the canonical `mix()` fit (OFV 118.51 vs 118.52), while `mixnum` gives a different, wrong objective (116.83). Collapsing is estimation-invariant by construction: `V <- mix(E1,p,E2)` and `V<-E1; if (mixest==2) V<-E2` both expand (symengine) to `rxEq(mixest,k)`. FOCEI and SAEM both estimate the pattern natively; the translated model also simulates via `rxSolve`.

> Note: fully *fitting* the bauer fixtures is blocked by a separate, pre-existing gap — their `$ERROR Y=F+F*EPS(1)` does not convert to a `~` endpoint (same on `main`, and on non-mixture `run001`/`run002`). That `$ERROR` conversion is intentionally out of scope here.

## Tests

New `tests/testthat/test-mix.R`: pure-function coverage of the collapse (per-component ifs, default+override, 3 populations, newline-joined blocks, non-collapsible cases) plus end-to-end assertions across the bauer supp7 mixture fixtures. No regressions across `test-abbrev.R`, `test-bauer-2019.R`, and the parsing suites (313 pass / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)