### PR TITLE
Remove the rxode2 piping-cache workaround; require rxode2 >= 5.1.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     dparser,
     lotri,
     Rcpp,
-    rxode2 (> 2.0.13),
+    rxode2 (>= 5.1.5),
     magrittr,
     cli,
     tools,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 # nonmem2rx 0.1.11
 
 
+* `nonmem2rx` now requires `rxode2` 5.1.5 or later.  That release fixes an
+  `rxode2` model-piping bug where a model piped from an import (which keeps a
+  persistent `meta` environment) shared the original's cached simulation
+  model, so states appended by piping (like a running `AUC`) were silently
+  dropped from the solve (#246).
+
 * NONMEM delay differential equation (DDE) models are now translated to
   rxode2's native `delay()`/`past()` syntax.  The DDE solvers `ADVAN16`
   (RADAR5) and `ADVAN18` (DDE_SOLVER) are accepted (in addition to the

--- a/R/linCmt.R
+++ b/R/linCmt.R
@@ -141,7 +141,7 @@
                      }
                      x
                    })
-  if (length(.w) > 0 && utils::packageVersion("rxode2") >= "4.0.0") {
+  if (length(.w) > 0) {
     .w  <- which(vapply(seq_along(.model),
                         function(i) {
                           identical(.model[[i]][[1]], quote(`<-`)) &&

--- a/R/nonmem2rx.R
+++ b/R/nonmem2rx.R
@@ -386,27 +386,6 @@
     .ret <- .tmp
     .minfo("done")
   }
-  if (utils::packageVersion("rxode2") <= "2.0.12") {
-    .expr <- .ret$lstExpr
-    .expr <- lapply(seq_along(.expr), function(i) {
-      .x <- .expr[[i]]
-      if (is.call(.x) && (identical(.x[[1]], quote(`<-`)) ||
-                            identical(.x[[1]], quote(`=`)))) {
-        if (is.call(.x[[2]]) && length(.x[[2]]) == 2L &&
-              is.numeric(.x[[2]][[2]]) &&
-              grepl("^rxddta",as.character(.x[[2]][[1]]))) {
-          .cur <- as.character(.x[[2]][[1]])
-          .w <- which(.cur == .c)
-          if (length(.w) == 1) {
-            .x[[2]] <- as.call(c(str2lang(.n[.w]), lapply(.x[[2]][-1], function(i) i)))
-          }
-        }
-      }
-      .x
-    })
-    .expr <- bquote(model(.(as.call(c(quote(`{`), .expr)))))
-    model(.ret) <- .expr
-  }
   .ret
 }
 

--- a/tests/testthat/test-advan5.R
+++ b/tests/testthat/test-advan5.R
@@ -174,10 +174,12 @@ test_that("nonmem2rx translates ADVAN5 to a matExp() model (default) equal to th
   # both models solve to the same values when random effects are zeroed
   .ev <- rxode2::et(amt=100, cmt="DEPOT")
   .ev <- rxode2::et(.ev, seq(0, 24, by=4))
+  # zeroRe() drops the sigma block entirely rather than fixing eps1 at 0, so
+  # eps1 (used only in the unchecked `y` line) must be supplied explicitly
   .so <- suppressWarnings(rxode2::rxSolve(rxode2::zeroRe(.ode), .ev, returnType="data.frame",
-                                          addDosing=FALSE, atol=1e-10, rtol=1e-10))
+                                          addDosing=FALSE, atol=1e-10, rtol=1e-10, params=c(eps1=0)))
   .sm <- suppressWarnings(rxode2::rxSolve(rxode2::zeroRe(.mex), .ev, returnType="data.frame",
-                                          addDosing=FALSE, atol=1e-10, rtol=1e-10))
+                                          addDosing=FALSE, atol=1e-10, rtol=1e-10, params=c(eps1=0)))
   # the matrix exponential is exact for the constant-coefficient linear system,
   # so it agrees with the ODE integrator to well within solver tolerance
   expect_equal(.so$ipred, .sm$ipred, tolerance=1e-8)

--- a/tests/testthat/test-piping.R
+++ b/tests/testthat/test-piping.R
@@ -13,27 +13,27 @@ withr::with_options(list(nonmem2rx.save=FALSE, nonmem2rx.load=FALSE, nonmem2rx.o
     expect_false(is.null(f$nonmemData))
     expect_true(!is.null(f$dfSub))
 
-    f2 <- f %>% ini(eta1 ~ 0.1)
+    f2 <- f |> ini(eta1 ~ 0.1)
     expect_true(inherits(f2, "nonmem2rx"))
     expect_false(is.null(f2$nonmemData))
     expect_true(is.null(f2$dfSub))
 
-    f2 <- f %>% model(cl <- exp(theta1))
+    f2 <- f |> model(cl <- exp(theta1))
     expect_true(inherits(f2, "nonmem2rx"))
     expect_false(is.null(f2$nonmemData))
     expect_true(is.null(f2$dfSub))
 
-    f2 <- f %>% ini(eta1=fixed)
+    f2 <- f |> ini(eta1=fixed)
     expect_false(is.null(f2$nonmemData))
     expect_true(!is.null(f2$dfSub))
     expect_true(inherits(f2, "nonmem2rx"))
 
-    f2 <- f %>% rxRename(eta.v=eta2)
+    f2 <- f |> rxRename(eta.v=eta2)
     expect_false(is.null(f2$nonmemData))
     expect_true(!is.null(f2$dfSub))
     expect_true(inherits(f2, "nonmem2rx"))
 
-    f2 <- f %>% dplyr::rename(eta.v=eta2)
+    f2 <- f |> dplyr::rename(eta.v=eta2)
     expect_false(is.null(f2$nonmemData))
     expect_true(!is.null(f2$dfSub))
     expect_true(inherits(f2, "nonmem2rx"))
@@ -55,12 +55,12 @@ withr::with_options(list(nonmem2rx.save=FALSE, nonmem2rx.load=FALSE, nonmem2rx.o
     # (nlmixr2/rxode2#1149).
     expect_false(is.null(f$simulationModel))
 
-    fAuc <- f %>% model(d/dt(AUC) <- f, append=TRUE)
+    fAuc <- f |> model(d/dt(AUC) <- f, append=TRUE)
 
     expect_true("AUC" %in% rxode2::rxState(fAuc))
     expect_true("AUC" %in% rxode2::rxModelVars(fAuc$simulationModel)$state)
 
-    ev <- rxode2::et(amt=120000, ii=12, until=24) %>%
+    ev <- rxode2::et(amt=120000, ii=12, until=24) |>
       rxode2::et(c(0, 4, 8, 11.999, 12, 24))
 
     s <- rxode2::rxSolve(fAuc, ev, returnType="data.frame")

--- a/tests/testthat/test-piping.R
+++ b/tests/testthat/test-piping.R
@@ -41,4 +41,30 @@ withr::with_options(list(nonmem2rx.save=FALSE, nonmem2rx.load=FALSE, nonmem2rx.o
 
 
   })
+
+  test_that("a state appended by piping is kept when solving (#246)", {
+    skip_on_cran()
+
+    f <- .nonmem2rx(system.file("mods/cpt/runODE032.ctl", package="nonmem2rx"), lst=".res",
+                    keep=NULL)
+
+    # nonmem2rx marks the NONMEM metadata sticky, so the `meta` environment (which
+    # caches the simulation model in `.simModelBase`) survives piping.  Realize the
+    # simulation model first so the cache is primed before the model changes; the
+    # piped model must not pick up the pre-append cached model
+    # (nlmixr2/rxode2#1149).
+    expect_false(is.null(f$simulationModel))
+
+    fAuc <- f %>% model(d/dt(AUC) <- f, append=TRUE)
+
+    expect_true("AUC" %in% rxode2::rxState(fAuc))
+    expect_true("AUC" %in% rxode2::rxModelVars(fAuc$simulationModel)$state)
+
+    ev <- rxode2::et(amt=120000, ii=12, until=24) %>%
+      rxode2::et(c(0, 4, 8, 11.999, 12, 24))
+
+    s <- rxode2::rxSolve(fAuc, ev, returnType="data.frame")
+    expect_true("AUC" %in% names(s))
+    expect_true(any(s$AUC > 0))
+  })
 })

--- a/vignettes/articles/simulate-extra-items.Rmd
+++ b/vignettes/articles/simulate-extra-items.Rmd
@@ -57,19 +57,6 @@ modAuc <- mod %>%
 modAuc
 ```
 
-```{r fixSimModelCache, include=FALSE}
-# Temporary workaround for an rxode2 model-piping cache bug
-# (nlmixr2/rxode2#1149): piping an imported model that keeps a persistent
-# `meta` environment leaves a stale simulation-model cache
-# (`meta$.simModelBase`), which drops the appended `AUC` state from the solve.
-# Clearing it forces the simulation model to rebuild. Remove once a fixed
-# rxode2 is released.
-if (is.environment(modAuc$meta) &&
-      exists(".simModelBase", envir = modAuc$meta, inherits = FALSE)) {
-  rm(list = ".simModelBase", envir = modAuc$meta)
-}
-```
-
 You can also use `append=NA` to pre-pend or `append=f` to put the ODE
 right after the `f` line in the model.
 


### PR DESCRIPTION
Closes #246.

The rxode2 fix for nlmixr2/rxode2#1149 (fork the `meta` environment on piping
instead of sharing it by reference) first shipped in **rxode2 5.1.5**, so the
vignette workaround is now dead code.

## Changes

* **Remove the `fixSimModelCache` chunk** from
  `vignettes/articles/simulate-extra-items.Rmd`.  It reached into rxode2's
  internal `meta$.simModelBase` cache slot from a vignette, which would have
  silently rotted if that internal name changed.

* **`DESCRIPTION`: `rxode2 (> 2.0.13)` -> `rxode2 (>= 5.1.5)`.**  The fix
  commit landed after the `v5.1.4` tag and is contained in `v5.1.5` (CRAN
  currently ships 5.1.6).

* **Add a regression test** (`tests/testthat/test-piping.R`).  The removed
  vignette chunk was the only thing covering this path.  The test primes the
  cached simulation model, appends `d/dt(AUC) <- f` by piping, and asserts the
  appended state reaches both `$simulationModel` and the solved output.
  Verified that it discriminates: re-sharing the `meta` env by reference makes
  the `AUC` assertion fail, and it passes against a fixed rxode2.

* **Drop two now-unreachable rxode2 version guards** (flagged by the
  antigravity review): `.replaceCmtNames()` in `R/nonmem2rx.R` carried a branch
  gated on `rxode2 <= 2.0.12`, and `.linCmt()` in `R/linCmt.R` gated a hunk on
  `rxode2 >= 4.0.0`.  Under the 5.1.5 floor the first can never run and the
  second is always true, so removing them is behavior-preserving.

## Verification

* Re-knit `simulate-extra-items.Rmd` without the workaround (twice: after the
  vignette change and again after the R changes) -- `plot(s, AUC)` renders and
  the per-interval AUC table populates.
* `test-piping.R`: 23 pass, 0 fail.
* Two antigravity (Gemini) review passes; the second returned no findings.
* Full local suite shows 30 pre-existing failures, all `error building model`
  from `implicit declaration of function 'linCmt'` in the locally installed
  rxode2 5.1.7 dev build.  Confirmed pre-existing by reverting `R/linCmt.R` and
  `R/nonmem2rx.R` to `main` and reproducing the same failure -- unrelated to
  this PR.  Filed upstream as nlmixr2/rxode2#1227: `rxode2()` decides whether to
  run the `linCmt()` expansion from a parser-global flag, and `rxGetModel()`
  short-circuits on an `rxModelVars` input without re-parsing, so the
  `rxModelVars()` -> `rxode2()` round-trip in
  `rxUiGet.simulationModelIwres()` (`R/rxUiGet.R:27-28`) emits `linCmt()`
  verbatim into the generated C.  Because that flag is global and sticky the
  failure is compile-order dependent, so it may not reproduce on every machine.
