### PR TITLE
docs: regenerate with roxygen2 8.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,4 +67,4 @@ Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Language: en-US
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -54,17 +54,19 @@ importFrom(dparser,mkdparse)
 importFrom(ggplot2,autoplot)
 importFrom(lotri,lotri)
 importFrom(magrittr,`%>%`)
-importFrom(rxode2,RxODE)
-importFrom(rxode2,`model<-`)
-importFrom(rxode2,expit)
-importFrom(rxode2,ini)
-importFrom(rxode2,logit)
-importFrom(rxode2,model)
-importFrom(rxode2,rxRename)
-importFrom(rxode2,rxSolve)
-importFrom(rxode2,rxUiGet)
-importFrom(rxode2,rxode)
-importFrom(rxode2,rxode2)
+importFrom(rxode2,
+  RxODE,
+  `model<-`,
+  expit,
+  ini,
+  logit,
+  model,
+  rxRename,
+  rxSolve,
+  rxUiGet,
+  rxode,
+  rxode2
+)
 importFrom(stats,setNames)
 importFrom(utils,read.csv)
 useDynLib(nonmem2rx, .registration=TRUE)


### PR DESCRIPTION
Regenerated the package documentation with roxygen2 8.1.0 (was 8.0.0).

The NAMESPACE change is formatting only: 8.1.0 writes a multi-symbol importFrom() as one grouped call rather than one call per symbol.  The parsed directive set is unchanged -- 68 directives before, 68 after.

0 files under man/ changed.  No R source and no exported behavior changed.