### PR TITLE
build: track header dependencies so an object cannot go stale

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,3 +24,4 @@
 ^CRAN-SUBMISSION$
 ^doc$
 ^Meta$
+^src/.*[.]d$

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs
 /doc/
 /Meta/
 .vexp/
+/src/*.d

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,17 @@
 # nonmem2rx 0.1.11
 
 
+## Internal
+
+- The build now tracks header dependencies.  R's rules rebuild an object only
+  when its own source is newer, so an incremental build silently kept objects
+  that had been compiled against an earlier version of a header they include.
+  That reaches across packages: a `LinkingTo` package's headers are just
+  another include path, so a struct whose layout changes there leaves objects
+  here compiled to the old layout and the resulting shared library mixes both
+  -- a corrupt binary rather than a compile error.  `src/Makevars*` now
+  compiles with `-MMD -MP` and reads back the generated `.d` files.
+
 * `nonmem2rx` now requires `rxode2` 5.1.5 or later.  That release fixes an
   `rxode2` model-piping bug where a model piped from an import (which keeps a
   persistent `meta` environment) shared the original's cached simulation

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,25 @@
+# -*- mode: makefile-gmake -*-
+
+PKG_CFLAGS = -MMD -MP
+PKG_CXXFLAGS = -MMD -MP
+
+################################################################################
+## Header dependency tracking.
+##
+## R's build rules make an object depend on its own source only, so an object
+## goes stale -- silently -- when a header it includes changes and the source
+## does not.  That reaches across packages too: a LinkingTo package's headers
+## are just another include path, so a struct that changes there leaves the
+## objects here compiled to the previous layout.
+##
+## -MMD (in PKG_CFLAGS/PKG_CXXFLAGS above) records each object's headers in a
+## .d file beside it; -MP emits a phony target per header so one that is later
+## renamed or deleted does not break the build.  The .d files the previous
+## build wrote are read back below.
+##
+## Makevars is read before shlib.mk defines "all", so without .DEFAULT_GOAL the
+## first target of the first .d file becomes make's default goal and the shared
+## library is never linked.
+################################################################################
+.DEFAULT_GOAL := all
+-include $(wildcard *.d)


### PR DESCRIPTION
R's build rules make an object depend on its own source alone, so make reuses an object whenever only a header it includes has changed.  Nothing warns; the object simply keeps whatever layout that header had when it was last compiled.

That crosses package boundaries.  A LinkingTo package's headers are just another include path, so when a struct there gains or reorders a field, the objects here that were compiled against the previous layout are kept and linked alongside freshly compiled ones.  The result is a shared library whose halves disagree about member offsets -- a corrupt binary rather than a compile error, surfacing as a segfault far from the cause.

Compile with -MMD -MP so each object records its headers in a .d file beside it, and read those files back.  -MP emits a phony target per header so renaming or deleting one does not break the next build.

.DEFAULT_GOAL := all is required, not cosmetic: Makevars is read before shlib.mk defines "all", so without it the first target of the first included .d file becomes make's default goal and the shared library is never linked even though its objects rebuild.